### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Build
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ScottBrenner/sm/security/code-scanning/2](https://github.com/ScottBrenner/sm/security/code-scanning/2)

To fix the problem, we should add a `permissions` block to the workflow. The safest and most general placement is at the root of the file, as this will apply to all jobs in the workflow unless overridden by any job-level `permissions` blocks. The minimal safe permission for such build/test workflows is `contents: read`, which restricts the GITHUB_TOKEN to read-only access to repository contents, as none of the workflow steps need write access. 

The change should be made right after the workflow’s name definition (after line 4, before `on:` at line 6) for clarity and conventions. Only the explicit addition of the block is necessary; no other code or changes (jobs, imports, etc.) are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
